### PR TITLE
Feature/27 동화 읽기 페이지 작업

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
+import 'react-native-gesture-handler';
 import 'expo-router/entry';

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo-av": "^15.1.7",
     "expo-camera": "^16.1.8",
     "expo-file-system": "^18.1.10",
+    "expo-linear-gradient": "~14.1.5",
     "expo-location": "^18.1.5",
     "expo-router": "^5.1.0",
     "expo-screen-orientation": "^8.1.7",
@@ -27,6 +28,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "react-native-gesture-handler": "^2.26.0",
+    "react-native-page-flipper": "github:chris24elias/react-native-page-flipper",
     "react-native-reanimated": "^3.17.4",
     "react-native-tts": "^4.1.1",
     "zustand": "^5.0.6"

--- a/patches/react-native-page-flipper@1.0.1.patch
+++ b/patches/react-native-page-flipper@1.0.1.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Components/Gradient.tsx b/src/Components/Gradient.tsx
+index 6278016fc87b3383a52332cec078af281459670f..8695ddf1b8427d4474cb12141abee1df771b0198 100644
+--- a/src/Components/Gradient.tsx
++++ b/src/Components/Gradient.tsx
+@@ -1,7 +1,6 @@
+ import React from 'react';
+-import LinearGradient, {
+-    LinearGradientProps,
+-} from 'react-native-linear-gradient';
++import { LinearGradient } from 'expo-linear-gradient';
++import type { LinearGradientProps } from 'expo-linear-gradient';
+ 
+ const Gradient: React.FC<LinearGradientProps> = (props) => {
+     return <LinearGradient {...props} />;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  react-native-page-flipper@1.0.1:
+    hash: e577tbtzk73kvkglmejsqovtcy
+    path: patches/react-native-page-flipper@1.0.1.patch
+
 importers:
 
   .:
@@ -35,6 +40,9 @@ importers:
       expo-file-system:
         specifier: ^18.1.10
         version: 18.1.10(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))
+      expo-linear-gradient:
+        specifier: ~14.1.5
+        version: 14.1.5(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       expo-location:
         specifier: ^18.1.5
         version: 18.1.5(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))
@@ -62,6 +70,9 @@ importers:
       react-native-gesture-handler:
         specifier: ^2.26.0
         version: 2.26.0(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-page-flipper:
+        specifier: github:chris24elias/react-native-page-flipper
+        version: https://codeload.github.com/chris24elias/react-native-page-flipper/tar.gz/db7ce43d8df22b706925d1eba8fe4664ef40ebbf(patch_hash=e577tbtzk73kvkglmejsqovtcy)(expo-linear-gradient@14.1.5(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-gesture-handler@2.26.0(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-linear-gradient@2.8.3(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.4(@babel/core@7.27.7)(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react-native-reanimated:
         specifier: ^3.17.4
         version: 3.17.4(@babel/core@7.27.7)(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -802,8 +813,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@modelcontextprotocol/sdk@1.17.3':
-    resolution: {integrity: sha512-JPwUKWSsbzx+DLFznf/QZ32Qa+ptfbUlHhRLrBQBAFu9iI1iYvizM4p+zhhRDceSsPutXp4z+R/HPVphlIiclg==}
+  '@modelcontextprotocol/sdk@1.18.0':
+    resolution: {integrity: sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ==}
     engines: {node: '>=18'}
 
   '@pkgjs/parseargs@0.11.0':
@@ -1670,6 +1681,13 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-linear-gradient@14.1.5:
+    resolution: {integrity: sha512-BSN3MkSGLZoHMduEnAgfhoj3xqcDWaoICgIr4cIYEx1GcHfKMhzA/O4mpZJ/WC27BP1rnAqoKfbclk1eA70ndQ==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-linking@7.1.5:
     resolution: {integrity: sha512-8g20zOpROW78bF+bLI4a3ZWj4ntLgM0rCewKycPL0jk9WGvBrBtFtwwADJgOiV1EurNp3lcquerXGlWS+SOQyA==}
@@ -2678,6 +2696,23 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-linear-gradient@2.8.3:
+    resolution: {integrity: sha512-KflAXZcEg54PXkLyflaSZQ3PJp4uC4whM7nT/Uot9m0e/qxFV3p6uor1983D1YOBJbJN7rrWdqIjq0T42jOJyA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  react-native-page-flipper@https://codeload.github.com/chris24elias/react-native-page-flipper/tar.gz/db7ce43d8df22b706925d1eba8fe4664ef40ebbf:
+    resolution: {tarball: https://codeload.github.com/chris24elias/react-native-page-flipper/tar.gz/db7ce43d8df22b706925d1eba8fe4664ef40ebbf}
+    version: 1.0.1
+    peerDependencies:
+      expo-linear-gradient: '*'
+      react: '>=16.8.0'
+      react-native: '>=0.6.0'
+      react-native-gesture-handler: '*'
+      react-native-linear-gradient: ^2.5.6
+      react-native-reanimated: '>=2.7.0 || ^3.0.0'
+
   react-native-reanimated@3.17.4:
     resolution: {integrity: sha512-vmkG/N5KZrexHr4v0rZB7ohPVseGVNaCXjGxoRo+NYKgC9+mIZAkg/QIfy9xxfJ73FfTrryO9iYUrxks3ZfKbA==}
     peerDependencies:
@@ -3131,8 +3166,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
     hasBin: true
 
   uuid@7.0.3:
@@ -3291,8 +3326,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.17:
-    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
 
   zustand@5.0.6:
     resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
@@ -4363,7 +4398,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@modelcontextprotocol/sdk@1.17.3':
+  '@modelcontextprotocol/sdk@1.18.0':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
@@ -5165,10 +5200,10 @@ snapshots:
 
   cursor-talk-to-figma-mcp@0.2.1:
     dependencies:
-      '@modelcontextprotocol/sdk': 1.17.3
-      uuid: 11.1.0
+      '@modelcontextprotocol/sdk': 1.18.0
+      uuid: 13.0.0
       ws: 8.18.3
-      zod: 4.0.17
+      zod: 4.1.8
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5339,6 +5374,12 @@ snapshots:
     dependencies:
       expo: 53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
+
+  expo-linear-gradient@14.1.5(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      expo: 53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-native: 0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)
 
   expo-linking@7.1.5(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -6449,6 +6490,20 @@ snapshots:
       react: 19.0.0
       react-native: 0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)
 
+  react-native-linear-gradient@2.8.3(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-native: 0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)
+
+  react-native-page-flipper@https://codeload.github.com/chris24elias/react-native-page-flipper/tar.gz/db7ce43d8df22b706925d1eba8fe4664ef40ebbf(patch_hash=e577tbtzk73kvkglmejsqovtcy)(expo-linear-gradient@14.1.5(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-gesture-handler@2.26.0(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-linear-gradient@2.8.3(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native-reanimated@3.17.4(@babel/core@7.27.7)(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      expo-linear-gradient: 14.1.5(expo@53.0.13(@babel/core@7.27.7)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-native: 0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0)
+      react-native-gesture-handler: 2.26.0(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-linear-gradient: 2.8.3(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react-native-reanimated: 3.17.4(@babel/core@7.27.7)(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+
   react-native-reanimated@3.17.4(@babel/core@7.27.7)(react-native@0.79.4(@babel/core@7.27.7)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:
       '@babel/core': 7.27.7
@@ -6959,7 +7014,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@11.1.0: {}
+  uuid@13.0.0: {}
 
   uuid@7.0.3: {}
 
@@ -7066,7 +7121,7 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.0.17: {}
+  zod@4.1.8: {}
 
   zustand@5.0.6(@types/react@19.0.14)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0)):
     optionalDependencies:

--- a/src/app/stories/[id]/read.tsx
+++ b/src/app/stories/[id]/read.tsx
@@ -6,32 +6,18 @@ import { useStoryReaderPage } from '../../../widgets/StoryReaderPage';
 export default function StoryReaderScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { 
-    currentPage, 
-    currentPageIndex, 
-    totalPages, 
+    pages,
+    initialPage,
     handleBack, 
-    handlePrevious, 
-    handleNext, 
-    canGoPrevious, 
-    canGoNext 
+    handlePageChange
   } = useStoryReaderPage(id || '');
-
-  if (!currentPage) {
-    return null;
-  }
 
   return (
     <StoryReaderPage
-      currentPage={currentPageIndex}
-      totalPages={totalPages}
-      storyTitle={currentPage.title}
-      storyContent={currentPage.content}
-      imageUrl={currentPage.imageUrl}
+      pages={pages}
+      initialPage={initialPage}
       onBack={handleBack}
-      onPrevious={handlePrevious}
-      onNext={handleNext}
-      canGoPrevious={canGoPrevious}
-      canGoNext={canGoNext}
+      onPageChange={handlePageChange}
     />
   );
 }

--- a/src/shared/components/PageFlipper/BookPage/BackShadow.tsx
+++ b/src/shared/components/PageFlipper/BookPage/BackShadow.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+    interpolate,
+    useAnimatedStyle,
+} from 'react-native-reanimated';
+import { Gradient } from '../Components/Gradient';
+
+type BackShadowProps = {
+    degrees: Animated.SharedValue<number>;
+    right: boolean;
+};
+
+const colors = ['rgba(0,0,0,0.0)', 'rgba(0,0,0,0.2)', 'rgba(0,0,0,0.7)'] as const;
+
+const rightPosition = {
+    start: { x: 0.5, y: 0 },
+    end: { x: 1, y: 0 },
+};
+
+const leftPosition = {
+    start: { x: 0.5, y: 0 },
+    end: { x: 0, y: 0 },
+};
+
+const BackShadow: React.FC<BackShadowProps> = ({ degrees, right }) => {
+    const position = right ? rightPosition : leftPosition;
+
+    const animatedStyle = useAnimatedStyle(() => {
+        const opacity = interpolate(
+            Math.abs(degrees.value),
+            [0, 130, 180],
+            [1, 0.5, 0]
+        );
+
+        return {
+            opacity,
+        };
+    });
+
+    return (
+        <Animated.View
+            style={[
+                {
+                    ...StyleSheet.absoluteFillObject,
+                    zIndex: 4,
+                },
+                animatedStyle,
+            ]}
+        >
+            <Gradient
+                {...position}
+                colors={colors}
+                style={{
+                    ...StyleSheet.absoluteFillObject,
+                }}
+            />
+        </Animated.View>
+    );
+};
+
+export default BackShadow;

--- a/src/shared/components/PageFlipper/BookPage/BookSpine.tsx
+++ b/src/shared/components/PageFlipper/BookPage/BookSpine.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Gradient } from '../Components/Gradient';
+import type { Size } from '../types';
+
+export type IBookSpineProps = {
+    right: boolean;
+    containerSize: Size;
+};
+
+const shadowColors = [
+    'rgba(0,0,0,0.3)',
+    'rgba(0,0,0,0.1)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+] as const;
+
+const BookSpine: React.FC<IBookSpineProps> = ({ right, containerSize }) => {
+    return (
+        <View
+            pointerEvents="none"
+            style={[
+                {
+                    position: 'absolute',
+                    height: '100%',
+                    width: containerSize.width / 2,
+                    zIndex: 1,
+                    opacity: 0.6,
+                },
+                right ? { left: 0 } : { right: 0 },
+            ]}
+        >
+            <Gradient
+                start={{ x: right ? 0 : 1, y: 0 }}
+                end={{ x: right ? 1 : 0, y: 0 }}
+                colors={shadowColors}
+                style={{
+                    flex: 1,
+                }}
+            />
+        </View>
+    );
+};
+
+export { BookSpine };

--- a/src/shared/components/PageFlipper/BookPage/BookSpine2.tsx
+++ b/src/shared/components/PageFlipper/BookPage/BookSpine2.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import Animated, {
+    interpolate,
+    useAnimatedStyle,
+} from 'react-native-reanimated';
+import { Gradient } from '../Components/Gradient';
+import type { Size } from '../types';
+
+export type IBookSpine2Props = {
+    right: boolean;
+    containerSize: Size;
+    degrees: Animated.SharedValue<number>;
+};
+
+const shadowColors = [
+    'rgba(0,0,0,0.3)',
+    'rgba(0,0,0,0.1)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+    'rgba(0,0,0,0)',
+] as const;
+
+const BookSpine2: React.FC<IBookSpine2Props> = ({
+    right,
+    degrees,
+    // containerSize,
+}) => {
+    const style = useAnimatedStyle(() => {
+        const opacity = interpolate(
+            Math.abs(degrees.value),
+            [0, 150, 180],
+            [0, 0, 0.65]
+        );
+        return {
+            opacity,
+        };
+    });
+
+    const position1 = right
+        ? {
+              start: { x: 1, y: 0 },
+              end: { x: 0, y: 0 },
+          }
+        : {
+              start: { x: 0, y: 0 },
+              end: { x: 1, y: 0 },
+          };
+
+    const position2 = !right
+        ? {
+              start: { x: 1, y: 0 },
+              end: { x: 0, y: 0 },
+          }
+        : {
+              start: { x: 0, y: 0 },
+              end: { x: 1, y: 0 },
+          };
+
+    return (
+        <Animated.View
+            pointerEvents="none"
+            style={[
+                {
+                    position: 'absolute',
+                    height: '100%',
+                    width: '100%',
+                    zIndex: 10000000,
+                    flexDirection: 'row',
+                },
+                style,
+            ]}
+        >
+            <Gradient
+                {...position1}
+                colors={shadowColors}
+                style={{
+                    width: '100%',
+                    height: '100%',
+                }}
+            />
+            <Gradient
+                {...position2}
+                colors={shadowColors}
+                style={[
+                    {
+                        width: '100%',
+                        height: '100%',
+                        position: 'absolute',
+                    },
+                    right ? { left: '100%' } : { right: '100%' },
+                ]}
+            />
+        </Animated.View>
+    );
+};
+
+export { BookSpine2 };

--- a/src/shared/components/PageFlipper/BookPage/FrontShadow.tsx
+++ b/src/shared/components/PageFlipper/BookPage/FrontShadow.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import Animated, {
+    Extrapolate,
+    interpolate,
+    useAnimatedStyle,
+} from 'react-native-reanimated';
+import { Gradient } from '../Components/Gradient';
+import { transformOrigin } from '../utils/utils';
+
+type FrontShadowProps = {
+    degrees: Animated.SharedValue<number>;
+    viewHeight: number;
+    right: boolean;
+};
+
+const FrontShadow: React.FC<FrontShadowProps> = ({
+    degrees,
+    viewHeight,
+    right,
+}) => {
+    const colors = [
+        'rgba(0,0,0,0.0)',
+        'rgba(0,0,0,0.2)',
+        'rgba(0,0,0,0.3)',
+        'rgba(0,0,0,0.6)',
+    ] as const;
+    const shadowWidth = 40;
+
+    const animatedStyle = useAnimatedStyle(() => {
+        const opacity = interpolate(
+            degrees.value,
+            [-180, -100, 0, 100, 180],
+            [0, 0.7, 1, 0.7, 0],
+            Extrapolate.CLAMP
+        );
+        const fix = right ? { right: -shadowWidth } : { left: -shadowWidth };
+
+        return {
+            opacity,
+            width: shadowWidth,
+            ...fix,
+
+            transform: [{ rotateY: !right ? '180deg' : '0deg' }],
+        };
+    });
+
+    // @ts-ignore - Reanimated transform 타입 복잡성
+    const animatedStyle2 = useAnimatedStyle(() => {
+        const scaleX = interpolate(
+            degrees.value,
+            [-150, 0, 150],
+            [6, 1, 6],
+            Extrapolate.CLAMP
+        );
+
+        return {
+            transform: [
+                ...transformOrigin({ x: -shadowWidth / 2, y: 0 }, [{ scaleX }]),
+            ],
+        };
+    });
+
+    return (
+        <Animated.View
+            style={[
+                {
+                    zIndex: 5000,
+                    height: viewHeight,
+                    position: 'absolute',
+                },
+                animatedStyle,
+            ]}
+        >
+            <Animated.View
+                style={[
+                    {
+                        height: viewHeight,
+                        width: shadowWidth,
+                    },
+                    animatedStyle2,
+                ]}
+            >
+                <Gradient
+                    start={{ x: 1, y: 0 }}
+                    end={{ x: 0, y: 0 }}
+                    colors={colors}
+                    style={[{ flex: 1 }]}
+                />
+            </Animated.View>
+        </Animated.View>
+    );
+};
+export default FrontShadow;

--- a/src/shared/components/PageFlipper/BookPage/PageShadow.tsx
+++ b/src/shared/components/PageFlipper/BookPage/PageShadow.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import Animated, {
+    interpolate,
+    useAnimatedStyle,
+} from 'react-native-reanimated';
+import { Gradient } from '../Components/Gradient';
+import type { Size } from '../types';
+
+type PageShadowProps = {
+    degrees: Animated.SharedValue<number>;
+    viewHeight: number;
+    right: boolean;
+    containerSize: Size;
+};
+
+const PageShadow: React.FC<PageShadowProps> = ({
+    degrees,
+    viewHeight,
+    right,
+    containerSize,
+}) => {
+    const colors = right
+        ? ([
+              'rgba(0,0,0,0.0)',
+              'rgba(0,0,0,0.0)',
+              'rgba(0,0,0,0.2)',
+              'rgba(0,0,0,0.6)',
+          ] as const)
+        : ([
+              'rgba(0,0,0,0.6)',
+              'rgba(0,0,0,0.2)',
+              'rgba(0,0,0,0.0)',
+              'rgba(0,0,0,0)',
+          ] as const);
+    const shadowWidth = containerSize.width * 0.02;
+    const animatedStyle = useAnimatedStyle(() => {
+        const opacity = interpolate(
+            Math.abs(degrees.value),
+            [0, 30, 55, 180],
+            [0, 0, 1, 0]
+        );
+        return {
+            opacity,
+        };
+    });
+
+    return (
+        <Animated.View
+            style={[
+                {
+                    zIndex: 2,
+                    height: viewHeight,
+                    position: 'absolute',
+                    width: shadowWidth,
+                },
+                right ? { left: -shadowWidth } : { right: -shadowWidth },
+                animatedStyle,
+            ]}
+        >
+            <Gradient
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 0 }}
+                colors={colors}
+                style={{
+                    flex: 1,
+                }}
+            />
+        </Animated.View>
+    );
+};
+export default PageShadow;

--- a/src/shared/components/PageFlipper/BookPage/index.tsx
+++ b/src/shared/components/PageFlipper/BookPage/index.tsx
@@ -1,0 +1,423 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, StyleSheet, View, ViewStyle } from 'react-native';
+import {
+    PanGestureHandler,
+    PanGestureHandlerGestureEvent,
+} from 'react-native-gesture-handler';
+import Animated, {
+    Easing,
+    Extrapolate,
+    interpolate,
+    runOnJS,
+    useAnimatedGestureHandler,
+    useAnimatedStyle,
+    useSharedValue,
+    withTiming,
+    WithTimingConfig,
+} from 'react-native-reanimated';
+import type { Page, Size } from '../types';
+import BackShadow from './BackShadow';
+import FrontShadow from './FrontShadow';
+import PageShadow from './PageShadow';
+import { BookSpine } from './BookSpine';
+import { BookSpine2 } from './BookSpine2';
+import { clamp, snapPoint } from '../utils/utils';
+export type IBookPageProps = {
+    right: boolean;
+    front: Page;
+    back: Page;
+    onPageFlip: any;
+    containerSize: Size;
+    isAnimatingRef: React.MutableRefObject<boolean>;
+    setIsAnimating: (val: boolean) => void;
+    isAnimating: boolean;
+    enabled: boolean;
+    isPressable: boolean;
+    getPageStyle: (right: boolean, front: boolean) => any;
+    single: boolean;
+    onFlipStart?: (id: number) => void;
+    onPageDragStart?: () => void;
+    onPageDrag?: () => void;
+    onPageDragEnd?: () => void;
+    renderPage?: (data: any) => any;
+};
+
+export type BookPageInstance = {
+    turnPage: () => void;
+};
+
+const timingConfig: WithTimingConfig = {
+    duration: 800,
+    easing: Easing.inOut(Easing.cubic),
+};
+
+const BookPage = React.forwardRef<BookPageInstance, IBookPageProps>(
+    (
+        {
+            right,
+            front,
+            back,
+            onPageFlip,
+            containerSize,
+            isAnimatingRef,
+            setIsAnimating,
+            isAnimating,
+            enabled,
+            isPressable,
+            getPageStyle,
+            single,
+            onFlipStart,
+            onPageDrag,
+            onPageDragEnd,
+            onPageDragStart,
+            renderPage,
+        },
+        ref
+    ) => {
+        const x = useSharedValue(0);
+        const isMounted = useRef(false);
+        const rotateYAsDeg = useSharedValue(0);
+        const [isDragging, setIsDragging] = useState(false);
+        const isDraggingRef = useRef(false);
+        const containerWidth = containerSize.width;
+        const containerHeight = containerSize.height;
+        const leftPSnapPoints = [0, containerWidth];
+        const rightPSnapPoints = [-containerWidth, 0];
+        const pSnapPoints = right ? rightPSnapPoints : leftPSnapPoints;
+        const gesturesEnabled = enabled && !isAnimating;
+        const showSpine = true;
+
+        // might not need this useEffect
+        // useEffect(() => {
+        //   if (!enabled) {
+        //     setIsDragging(false);
+        //   }
+        // }, [enabled]);
+
+        useEffect(() => {
+            isMounted.current = true;
+            return () => {
+                isMounted.current = false;
+            };
+        }, []);
+
+        const turnPage = useCallback(() => {
+            setIsDragging(true);
+            setIsAnimating(true);
+            const id = right ? 1 : -1;
+
+            if (onFlipStart && typeof onFlipStart === 'function') {
+                onFlipStart(id);
+            }
+            rotateYAsDeg.value = withTiming(
+                right ? 180 : -180,
+                timingConfig,
+                () => {
+                    runOnJS(onPageFlip)(id, false);
+                }
+            );
+        }, [
+            onFlipStart,
+            setIsDragging,
+            right,
+            onPageFlip,
+            rotateYAsDeg,
+            setIsAnimating,
+        ]);
+
+        React.useImperativeHandle(
+            ref,
+            () => ({
+                turnPage,
+            }),
+            [turnPage]
+        );
+
+        const onDrag = useCallback((val: boolean) => {
+            if (!isMounted.current) {
+                return;
+            }
+
+            if (isDraggingRef.current === val) {
+                // same value
+                return;
+            }
+
+            setIsDragging(val);
+            isDraggingRef.current = val;
+        }, []);
+
+        const backStyle = useAnimatedStyle(() => {
+            const degrees = rotateYAsDeg.value;
+            const x = right
+                ? interpolate(
+                      degrees,
+                      [0, 180],
+                      [containerWidth / 2, -containerWidth / 2]
+                  )
+                : interpolate(degrees, [-180, 0], [containerWidth / 2, 0]);
+
+            const w = right
+                ? interpolate(degrees, [0, 180], [0, containerWidth / 2])
+                : interpolate(degrees, [-180, 0], [containerWidth / 2, 0]);
+            return {
+                width: Math.ceil(w),
+                zIndex: 2,
+                transform: [{ translateX: x }],
+            };
+        });
+
+        const frontStyle = useAnimatedStyle(() => {
+            const degrees = rotateYAsDeg.value;
+
+            const w = right
+                ? interpolate(
+                      degrees,
+                      [0, 90],
+                      [containerWidth / 2, 0],
+                      Extrapolate.CLAMP
+                  )
+                : interpolate(
+                      degrees,
+                      [-90, 0],
+                      [0, containerWidth / 2],
+                      Extrapolate.CLAMP
+                  );
+
+            const style: ViewStyle = {
+                zIndex: 1,
+                width: Math.floor(w),
+            };
+
+            if (right) {
+                style['left'] = 0;
+            } else {
+                style['right'] = 0;
+            }
+
+            return style;
+        });
+
+        const containerStyle = useAnimatedStyle(() => {
+            return {
+                flex: 1,
+                // backgroundColor: 'white',
+                zIndex: isDragging ? 100 : 0,
+            };
+        });
+
+        const animatedBackPageStyle = useAnimatedStyle(() => {
+            const l = right
+                ? 0
+                : interpolate(
+                      rotateYAsDeg.value,
+                      [-180, 0],
+                      single
+                          ? [0, -containerWidth / 2]
+                          : [-containerWidth / 2, -containerWidth]
+                  );
+
+            return {
+                left: l,
+            };
+        });
+
+        const onPanGestureHandler = useAnimatedGestureHandler<
+            PanGestureHandlerGestureEvent,
+            { x: number }
+        >({
+            // @ts-ignore
+            onStart: (event, ctx) => {
+                if (onPageDragStart && typeof onPageDragStart === 'function') {
+                    runOnJS(onPageDragStart)();
+                }
+                ctx.x = x.value;
+            },
+            onActive: (event, ctx) => {
+                runOnJS(onDrag)(true);
+                x.value = ctx.x + event.translationX;
+                rotateYAsDeg.value = interpolate(
+                    x.value,
+                    [-containerWidth, 0, containerWidth],
+                    [180, 0, -180],
+                    Extrapolate.CLAMP
+                );
+
+                if (onPageDrag && typeof onPageDrag === 'function') {
+                    runOnJS(onPageDrag)();
+                }
+            },
+            onEnd: (event) => {
+                if (onPageDragEnd && typeof onPageDragEnd === 'function') {
+                    runOnJS(onPageDragEnd)();
+                }
+
+                const snapTo = snapPoint(x.value, event.velocityX, pSnapPoints);
+                const id = snapTo > 0 ? -1 : snapTo < 0 ? 1 : 0;
+                const degrees = snapTo > 0 ? -180 : snapTo < 0 ? 180 : 0;
+                x.value = snapTo;
+
+                if (rotateYAsDeg.value === degrees) {
+                    runOnJS(onPageFlip)(id, false);
+                } else {
+                    runOnJS(setIsAnimating)(true);
+
+                    const progress =
+                        Math.abs(rotateYAsDeg.value - degrees) / 100;
+                    const duration = clamp(
+                        800 * progress - Math.abs(0.1 * event.velocityX),
+                        350,
+                        1000
+                    );
+
+                    rotateYAsDeg.value = withTiming(
+                        degrees,
+                        {
+                            ...timingConfig,
+                            duration: duration,
+                        },
+                        () => {
+                            if (snapTo === 0) {
+                                runOnJS(onDrag)(false);
+                            }
+                            runOnJS(onPageFlip)(id, false);
+                        }
+                    );
+                }
+            },
+        });
+
+        if (!front || !back) {
+            return null;
+        }
+
+        const frontPageStyle = getPageStyle(right, true);
+        const backPageStyle = getPageStyle(right, false);
+
+        const frontUrl = right ? front.right : front.left;
+        const backUrl = right ? back.left : back.right;
+        return (
+            <PanGestureHandler
+                onGestureEvent={onPanGestureHandler}
+                enabled={gesturesEnabled}
+            >
+                <Animated.View style={containerStyle}>
+                    {isPressable && (
+                        <Pressable
+                            disabled={isAnimating}
+                            onPress={() => {
+                                if (!isAnimatingRef.current) turnPage();
+                            }}
+                            style={[
+                                {
+                                    position: 'absolute',
+                                    height: '100%',
+                                    width: '25%',
+                                    zIndex: 10000,
+                                },
+                                right ? { right: 0 } : { left: 0 },
+                            ]}
+                        />
+                    )}
+
+                    {/* BACK */}
+                    <Animated.View
+                        style={[
+                            styles.pageContainer,
+                            backStyle,
+                            { overflow: 'visible' },
+                        ]}
+                    >
+                        <View style={styles.pageContainer}>
+                            {backUrl ? (
+                                renderPage && (
+                                    <Animated.View
+                                        style={[
+                                            backPageStyle,
+                                            animatedBackPageStyle,
+                                        ]}
+                                    >
+                                        {renderPage(backUrl)}
+                                    </Animated.View>
+                                )
+                            ) : (
+                                <BlankPage />
+                            )}
+                        </View>
+
+                        <BackShadow {...{ degrees: rotateYAsDeg, right }} />
+                        <FrontShadow
+                            {...{
+                                right,
+                                degrees: rotateYAsDeg,
+                                width: containerWidth,
+                                viewHeight: containerHeight,
+                            }}
+                        />
+
+                        <PageShadow
+                            {...{
+                                right,
+                                degrees: rotateYAsDeg,
+                                width: containerWidth,
+                                viewHeight: containerHeight,
+                                containerSize,
+                            }}
+                        />
+
+                        {showSpine && (
+                            <BookSpine2
+                                right={right}
+                                degrees={rotateYAsDeg}
+                                containerSize={containerSize}
+                            />
+                        )}
+                    </Animated.View>
+                    {/* FRONT */}
+                    <Animated.View style={[styles.pageContainer, frontStyle]}>
+                        {frontUrl ? (
+                            renderPage && (
+                                <Animated.View style={[frontPageStyle]}>
+                                    {renderPage(frontUrl)}
+                                </Animated.View>
+                            )
+                        ) : (
+                            <BlankPage />
+                        )}
+                        {showSpine && (
+                            <BookSpine
+                                right={right}
+                                containerSize={containerSize}
+                            />
+                        )}
+                    </Animated.View>
+                </Animated.View>
+            </PanGestureHandler>
+        );
+    }
+);
+
+export { BookPage };
+
+const BlankPage = () => (
+    <View
+        style={{ ...StyleSheet.absoluteFillObject, backgroundColor: '#fff' }}
+    />
+);
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    pageContainer: {
+        height: '100%',
+        width: '100%',
+        position: 'absolute',
+        backfaceVisibility: 'hidden',
+        overflow: 'hidden',
+        // justifyContent: 'center',
+        // alignItems: 'flex-end',
+        // backgroundColor: 'rgba(0,0,0,0)',
+        // backgroundColor: 'white',
+    },
+});

--- a/src/shared/components/PageFlipper/BookPageBackground.tsx
+++ b/src/shared/components/PageFlipper/BookPageBackground.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { BookSpine } from './BookPage/BookSpine';
+import type { Size } from './types';
+
+type IBookPageBackgroundProps = {
+    left: string;
+    right: string;
+    isFirstPage: boolean;
+    isLastPage: boolean;
+    containerSize: Size;
+    getPageStyle: (right: boolean, front: boolean) => any;
+    renderPage?: (data: any) => any;
+    renderLastPage?: () => any;
+    shouldRenderLastPage: boolean;
+};
+
+const BookPageBackground: React.FC<IBookPageBackgroundProps> = ({
+    left,
+    right,
+    isFirstPage,
+    isLastPage,
+    containerSize,
+    getPageStyle,
+    renderPage,
+    renderLastPage,
+    shouldRenderLastPage,
+}) => {
+    const leftPageStyle = getPageStyle(false, true);
+    const rightPageStyle = getPageStyle(true, true);
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.pageContainer}>
+                {left && renderPage && (
+                    <View style={[leftPageStyle]}>{renderPage(left)}</View>
+                )}
+                {isFirstPage && (
+                    <BookSpine right={false} containerSize={containerSize} />
+                )}
+            </View>
+            <View style={styles.pageContainer}>
+                {right && renderPage && (
+                    <View style={[rightPageStyle]}>{renderPage(right)}</View>
+                )}
+                {isLastPage && (
+                    <BookSpine right={true} containerSize={containerSize} />
+                )}
+
+                {shouldRenderLastPage && renderLastPage && (
+                    <View style={[rightPageStyle, { zIndex: -1 }]}>
+                        {renderLastPage()}
+                    </View>
+                )}
+            </View>
+        </View>
+    );
+};
+
+export { BookPageBackground };
+
+const styles = StyleSheet.create({
+    pageContainer: {
+        flex: 1,
+        backfaceVisibility: 'hidden',
+        overflow: 'hidden',
+        justifyContent: 'center',
+        // backgroundColor: 'white',
+    },
+    container: {
+        position: 'absolute',
+        zIndex: -1,
+        height: '100%',
+        width: '100%',
+        flexDirection: 'row',
+    },
+});

--- a/src/shared/components/PageFlipper/Components/Gradient.tsx
+++ b/src/shared/components/PageFlipper/Components/Gradient.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { LinearGradient } from 'expo-linear-gradient';
+import type { LinearGradientProps } from 'expo-linear-gradient';
+
+const Gradient: React.FC<LinearGradientProps> = (props) => {
+    return <LinearGradient {...props} />;
+};
+
+export { Gradient };

--- a/src/shared/components/PageFlipper/Components/Gradient.web.tsx
+++ b/src/shared/components/PageFlipper/Components/Gradient.web.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { LinearGradient, LinearGradientProps } from 'expo-linear-gradient';
+
+const Gradient: React.FC<LinearGradientProps> = (props) => {
+    return <LinearGradient {...props} />;
+};
+
+export { Gradient };

--- a/src/shared/components/PageFlipper/hooks/usePrevious.ts
+++ b/src/shared/components/PageFlipper/hooks/usePrevious.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+
+// Hook
+const usePrevious = <T>(value: T) => {
+    // The ref object is a generic container whose current property is mutable ...
+    // ... and can hold any value, similar to an instance property on a class
+    const ref = useRef<T | undefined>(undefined);
+    // Store current value in ref
+    useEffect(() => {
+        ref.current = value;
+    }, [value]); // Only re-run if value changes
+    // Return previous value (happens before update in useEffect above)
+    return ref.current;
+};
+export default usePrevious;

--- a/src/shared/components/PageFlipper/hooks/useSetState.ts
+++ b/src/shared/components/PageFlipper/hooks/useSetState.ts
@@ -1,0 +1,22 @@
+import { useCallback, useState } from 'react';
+
+// eslint-disable-next-line
+const useSetState = <T extends object>(
+    initialState: T = {} as T
+): [T, (patch: Partial<T> | ((prevState: T) => Partial<T>)) => void] => {
+    const [state, set] = useState<T>(initialState);
+    const setState = useCallback(
+        (patch: Partial<T>) => {
+            set((prevState) => ({
+                ...prevState,
+                ...(patch instanceof Function ? patch(prevState) : patch),
+            }));
+        },
+        [set]
+    );
+
+    // @ts-ignore - 타입 복잡성으로 인한 임시 무시
+    return [state, setState];
+};
+
+export default useSetState;

--- a/src/shared/components/PageFlipper/hooks/useWhyDidYouUpdate.ts
+++ b/src/shared/components/PageFlipper/hooks/useWhyDidYouUpdate.ts
@@ -1,0 +1,37 @@
+/* eslint-disable */
+// @ts-nocheck
+
+import { useEffect, useRef } from 'react';
+
+function useWhyDidYouUpdate(name, props) {
+    // Get a mutable ref object where we can store props ...
+    // ... for comparison next time this hook runs.
+    const previousProps = useRef();
+    useEffect(() => {
+        if (previousProps.current) {
+            // Get all keys from previous and current props
+            const allKeys = Object.keys({ ...previousProps.current, ...props });
+            // Use this object to keep track of changed props
+            const changesObj = {};
+            // Iterate through keys
+            allKeys.forEach((key) => {
+                // If previous is different from current
+                if (previousProps.current[key] !== props[key]) {
+                    // Add to changesObj
+                    changesObj[key] = {
+                        from: previousProps.current[key],
+                        to: props[key],
+                    };
+                }
+            });
+            // If changesObj not empty then output to console
+            if (Object.keys(changesObj).length) {
+                console.log('[why-did-you-update]', name, changesObj);
+            }
+        }
+        // Finally update previousProps with current props for next hook call
+        previousProps.current = props;
+    });
+}
+
+export default useWhyDidYouUpdate;

--- a/src/shared/components/PageFlipper/index.tsx
+++ b/src/shared/components/PageFlipper/index.tsx
@@ -1,0 +1,595 @@
+import usePrevious from './hooks/usePrevious';
+import useSetState from './hooks/useSetState';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import { useRef } from 'react';
+import { LayoutChangeEvent, StyleSheet, View, ViewStyle } from 'react-native';
+import { BookPage, BookPageInstance, IBookPageProps } from './BookPage';
+import {
+    BookPagePortrait,
+    PortraitBookInstance,
+} from './portrait/BookPagePortrait';
+import type { Page, Size } from './types';
+import { createPages } from './utils/utils';
+import { BookPageBackground } from './BookPageBackground';
+
+export type IPageFlipperProps = {
+    data: string[];
+    enabled?: boolean; // gestures
+    pressable?: boolean; // are the pages tappable
+    singleImageMode?: boolean;
+    renderLastPage?: () => React.ReactElement;
+    portrait?: boolean;
+    onFlippedEnd?: (index: number) => void;
+    onFlipStart?: (id: number) => void;
+    onPageDragStart?: () => void;
+    onPageDrag?: () => void;
+    onPageDragEnd?: () => void;
+    onEndReached?: () => void;
+    onInitialized?: (props: any) => void;
+    renderContainer?: () => any;
+    renderPage?: (data: any) => any;
+    pageSize: Size;
+    contentContainerStyle: ViewStyle;
+};
+
+export type PageFlipperInstance = {
+    goToPage: (index: number) => void;
+    previousPage: () => void;
+    nextPage: () => void;
+};
+
+export type State = {
+    pageIndex: number;
+    pages: Page[];
+    isAnimating: boolean;
+    initialized: boolean;
+    // pageSize: Size;
+    prev: Page;
+    current: Page;
+    next: Page;
+    nextPageIndex?: number;
+    isPortrait: boolean;
+};
+
+const debug = true;
+
+const logger = (msg: string) => {
+    if (debug) {
+        console.log(msg);
+    }
+};
+
+const PageFlipper = React.forwardRef<PageFlipperInstance, IPageFlipperProps>(
+    (
+        {
+            data,
+            enabled = true,
+            pressable = true,
+            singleImageMode = true,
+            renderLastPage,
+            portrait = false,
+            onFlippedEnd,
+            onFlipStart,
+            onPageDrag,
+            onPageDragEnd,
+            onPageDragStart,
+            onEndReached,
+            onInitialized,
+            renderContainer,
+            renderPage,
+            pageSize = { height: 600, width: 400 },
+            contentContainerStyle,
+        },
+        ref
+    ) => {
+        const [{ width, height }, setLayout] = useState({
+            height: 0,
+            width: 0,
+        });
+        const [state, setState] = useSetState<State>({
+            pageIndex: 0,
+            pages: [],
+            isAnimating: false,
+            initialized: false,
+            // pageSize: { width: 0, height: 0 },
+            prev: { left: '', right: '' },
+            current: { left: '', right: '' },
+            next: { left: '', right: '' },
+            nextPageIndex: undefined,
+            isPortrait: portrait,
+        });
+        const isAnimatingRef = useRef(false);
+        const prevBookPage = useRef<BookPageInstance>(null);
+        const nextBookPage = useRef<BookPageInstance>(null);
+        const portraitBookPage = useRef<PortraitBookInstance>(null);
+        const previousPortrait = usePrevious(portrait);
+        const containerSize = useMemo(() => {
+            if (!state.initialized) {
+                return {
+                    width: 0,
+                    height: 0,
+                };
+            }
+            let size = {
+                height: pageSize.height,
+                width:
+                    singleImageMode && !state.isPortrait
+                        ? pageSize.width * 2
+                        : pageSize.width,
+            };
+
+            if (!singleImageMode && state.isPortrait) {
+                size = {
+                    height: pageSize.height,
+                    width: pageSize.width / 2,
+                };
+            }
+
+            let finalSize: Size;
+
+            // corrections
+            if (size.height > size.width) {
+                const ratio = size.height / size.width;
+                finalSize = {
+                    height: width * ratio,
+                    width,
+                };
+
+                if (finalSize.height > height) {
+                    const diff = finalSize.height / height;
+                    finalSize.height = height;
+                    finalSize.width = finalSize.width / diff;
+                }
+            } else {
+                const ratio = size.width / size.height;
+                finalSize = {
+                    height,
+                    width: height * ratio,
+                };
+                if (finalSize.width > width) {
+                    const diff = finalSize.width / width;
+                    finalSize.width = width;
+                    finalSize.height = finalSize.height / diff;
+                }
+            }
+
+            return finalSize;
+        }, [
+            height,
+            singleImageMode,
+            width,
+            state.initialized,
+            state.isPortrait,
+            pageSize.height,
+            pageSize.width,
+        ]);
+
+        useEffect(() => {
+            const initialize = async () => {
+                try {
+                    const allPages = createPages({
+                        portrait,
+                        singleImageMode,
+                        data,
+                    });
+
+                    let adjustedIndex = getAdjustedIndex(allPages);
+
+                    setState({
+                        initialized: true,
+                        pages: allPages,
+                        prev: allPages[adjustedIndex - 1],
+                        current: allPages[adjustedIndex],
+                        next: allPages[adjustedIndex + 1],
+                        pageIndex: adjustedIndex,
+                        isPortrait: portrait,
+                    });
+
+                    if (onInitialized) {
+                        onInitialized({
+                            pages: allPages,
+                            index: adjustedIndex,
+                        });
+                    }
+                } catch (error) {
+                    console.error('error', error);
+                }
+            };
+            initialize();
+            // eslint-disable-next-line
+        }, [data, portrait, singleImageMode]);
+
+        useEffect(() => {
+            if (state.nextPageIndex !== undefined) {
+                if (!state.isPortrait) {
+                    if (state.nextPageIndex > state.pageIndex) {
+                        nextBookPage.current?.turnPage();
+                    } else {
+                        prevBookPage.current?.turnPage();
+                    }
+                } else {
+                    portraitBookPage.current?.turnPage(
+                        state.nextPageIndex > state.pageIndex ? 1 : -1
+                    );
+                }
+            }
+            // eslint-disable-next-line
+        }, [state.nextPageIndex]);
+
+        const goToPage = useCallback(
+            (index: number) => {
+                if (index === undefined || index === null) {
+                    logger('index cannot be undefined or null');
+                    return;
+                }
+
+                if (typeof index !== 'number' || isNaN(index)) {
+                    logger('index must be a number');
+                    return;
+                }
+
+                if (index < 0 || index > state.pages.length - 1) {
+                    logger('invalid page');
+                    return;
+                }
+
+                if (isAnimatingRef.current) {
+                    logger('is already animating');
+                    return;
+                }
+
+                if (index === state.pageIndex) {
+                    logger('same page');
+                    return;
+                }
+
+                if (index > state.pageIndex) {
+                    setState({
+                        next: state.pages[index],
+                        nextPageIndex: index,
+                    });
+                } else {
+                    setState({
+                        prev: state.pages[index],
+                        nextPageIndex: index,
+                    });
+                }
+            },
+            [setState, state.pageIndex, state.pages]
+        );
+
+        const previousPage = useCallback(() => {
+            const newIndex = state.pageIndex - 1;
+            goToPage(newIndex);
+        }, [goToPage, state.pageIndex]);
+
+        const nextPage = useCallback(() => {
+            const newIndex = state.pageIndex + 1;
+            goToPage(newIndex);
+        }, [goToPage, state.pageIndex]);
+
+        React.useImperativeHandle(
+            ref,
+            () => ({
+                goToPage,
+                nextPage,
+                previousPage,
+            }),
+            [goToPage, nextPage, previousPage]
+        );
+
+        const getAdjustedIndex = (allPages: any[]) => {
+            // THIS NEEDS REWORKING
+            let adjustedIndex = state.pageIndex;
+            if (
+                previousPortrait !== undefined &&
+                previousPortrait !== portrait &&
+                singleImageMode
+            ) {
+                if (portrait) {
+                    adjustedIndex *= 2;
+                } else {
+                    adjustedIndex = Math.floor(
+                        adjustedIndex % 2 === 0
+                            ? adjustedIndex / 2
+                            : (adjustedIndex - 1) / 2
+                    );
+                }
+            }
+
+            if (adjustedIndex < 0 || adjustedIndex > allPages.length - 1) {
+                // invalid index, reset to 0
+                adjustedIndex = 0;
+            }
+            return adjustedIndex;
+        };
+
+        const onLayout = (e: LayoutChangeEvent) => {
+            setLayout({
+                height: e.nativeEvent.layout.height,
+                width: e.nativeEvent.layout.width,
+            });
+        };
+
+        const onPageFlipped = useCallback(
+            (index: number) => {
+                const newIndex =
+                    state.nextPageIndex !== undefined
+                        ? state.nextPageIndex
+                        : state.pageIndex + index;
+
+                if (newIndex < 0 || newIndex > state.pages.length - 1) {
+                    // this if condition theoretically should never occur in the first place, so it could be removed but it's here just in case
+                    logger('invalid page');
+
+                    setState({
+                        isAnimating: false,
+                        nextPageIndex: undefined,
+                    });
+                    isAnimatingRef.current = false;
+                    return;
+                }
+
+                const prev = state.pages[newIndex - 1];
+                const current = state.pages[newIndex];
+                const next = state.pages[newIndex + 1];
+                setState({
+                    pageIndex: newIndex,
+                    isAnimating: false,
+                    prev,
+                    current,
+                    next,
+                    nextPageIndex: undefined,
+                });
+                isAnimatingRef.current = false;
+                if (onFlippedEnd && typeof onFlippedEnd === 'function') {
+                    onFlippedEnd(newIndex);
+                }
+
+                if (newIndex === state.pages.length - 1 && onEndReached) {
+                    onEndReached();
+                }
+            },
+            [
+                onEndReached,
+                onFlippedEnd,
+                setState,
+                state.nextPageIndex,
+                state.pageIndex,
+                state.pages,
+            ]
+        );
+
+        const setIsAnimating = useCallback(
+            (val: boolean) => {
+                setState({
+                    isAnimating: val,
+                });
+                isAnimatingRef.current = val;
+            },
+            [setState]
+        );
+
+        const getPageStyle = (right: boolean, front: boolean) => {
+            if (!singleImageMode && isPortrait) {
+                const pageStyle: any = {
+                    height: containerSize.height,
+                    width: containerSize.width * 2,
+                    position: 'absolute',
+                };
+
+                const isEvenPage = pageIndex % 2 === 0;
+
+                if (front) {
+                    if (isEvenPage) {
+                        pageStyle.left = right ? 0 : -containerSize.width;
+                    } else {
+                        pageStyle.left = right ? -containerSize.width : 0;
+                    }
+                } else {
+                    if (isEvenPage) {
+                        pageStyle.left = right ? -containerSize.width : 0;
+                    } else {
+                        pageStyle.left = right ? 0 : -containerSize.width;
+                    }
+                }
+                return pageStyle;
+            }
+
+            const pageStyle: any = {
+                height: containerSize.height,
+                width:
+                    singleImageMode && !isPortrait
+                        ? containerSize.width / 2
+                        : containerSize.width,
+                position: 'absolute',
+            };
+
+            const offset = singleImageMode ? 0 : -containerSize.width / 2;
+
+            if (isPortrait && front) {
+                pageStyle.left = 0;
+            } else if ((front && right) || (!front && right)) {
+                // front right or back right
+                pageStyle.left = offset;
+            } else if (front && !right) {
+                // front left
+                pageStyle.right = offset;
+            }
+
+            return pageStyle;
+        };
+
+        if (!state.initialized) {
+            return null;
+        }
+
+        const {
+            current,
+            pageIndex,
+            pages,
+            next,
+            prev,
+            isPortrait,
+            isAnimating,
+        } = state;
+        const isFirstPage = pageIndex === 0;
+        const isLastPage = pageIndex === pages.length - 1;
+        const isSecondToLastPage = pageIndex === pages.length - 2;
+        const shouldRenderLastPage =
+            (isSecondToLastPage || isLastPage) &&
+            singleImageMode &&
+            data.length % 2 !== 0;
+
+        const bookPageProps: Omit<IBookPageProps, 'right' | 'front' | 'back'> =
+            {
+                containerSize: containerSize,
+                isAnimating: isAnimating,
+                enabled,
+                setIsAnimating: setIsAnimating,
+                isAnimatingRef: isAnimatingRef,
+                onPageFlip: onPageFlipped,
+                getPageStyle,
+                single: singleImageMode,
+                onFlipStart,
+                onPageDrag,
+                onPageDragEnd,
+                onPageDragStart,
+                isPressable: pressable,
+                renderPage,
+            };
+
+        const ContentWrapper = renderContainer ? renderContainer : Wrapper;
+
+        return (
+            <View style={styles.container} onLayout={onLayout}>
+                <View
+                    style={[
+                        styles.contentContainer,
+                        {
+                            height: containerSize.height,
+                            width: containerSize.width,
+                        },
+                        contentContainerStyle,
+                    ]}
+                >
+                    <ContentWrapper>
+                        {!isPortrait ? (
+                            <View style={styles.content}>
+                                {!prev ? (
+                                    <Empty />
+                                ) : (
+                                    <BookPage
+                                        ref={prevBookPage}
+                                        right={false}
+                                        front={current}
+                                        back={prev}
+                                        key={`left${pageIndex}`}
+                                        {...bookPageProps}
+                                    />
+                                )}
+                                {!next ? (
+                                    <Empty />
+                                ) : (
+                                    <BookPage
+                                        ref={nextBookPage}
+                                        right
+                                        front={current}
+                                        back={next}
+                                        key={`right${pageIndex}`}
+                                        {...bookPageProps}
+                                    />
+                                )}
+                                <BookPageBackground
+                                    left={!prev ? current.left : prev.left}
+                                    right={!next ? current.right : next.right}
+                                    isFirstPage={isFirstPage}
+                                    isLastPage={isLastPage}
+                                    getPageStyle={getPageStyle}
+                                    containerSize={containerSize}
+                                    renderPage={renderPage}
+                                    renderLastPage={renderLastPage}
+                                    shouldRenderLastPage={shouldRenderLastPage}
+                                />
+                            </View>
+                        ) : (
+                            <View style={styles.portraitContent}>
+                                <View
+                                    style={{ ...StyleSheet.absoluteFillObject }}
+                                >
+                                    <BookPagePortrait
+                                        {...bookPageProps}
+                                        current={current}
+                                        prev={prev}
+                                        next={next}
+                                        onPageFlip={onPageFlipped}
+                                        key={`right${pageIndex}`}
+                                        ref={portraitBookPage}
+                                    />
+                                </View>
+                                {next && (
+                                    <View
+                                        style={{
+                                            ...StyleSheet.absoluteFillObject,
+                                            zIndex: -5,
+                                            overflow: 'hidden',
+                                        }}
+                                    >
+                                        {renderPage && (
+                                            <View
+                                                style={getPageStyle(
+                                                    true,
+                                                    false
+                                                )}
+                                            >
+                                                {renderPage(next.right)}
+                                            </View>
+                                        )}
+                                    </View>
+                                )}
+                            </View>
+                        )}
+                    </ContentWrapper>
+                </View>
+            </View>
+        );
+    }
+);
+
+export default React.memo(PageFlipper);
+
+const Wrapper = (props: any) => <View style={styles.wrap} {...props} />;
+
+const Empty = () => <View style={styles.container} pointerEvents="none" />;
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    wrap: {
+        flex: 1,
+    },
+    contentContainer: {
+        flexDirection: 'row',
+        // shadowColor: '#000',
+        // shadowOffset: {
+        //     width: 0,
+        //     height: 2,
+        // },
+        // shadowOpacity: 0.25,
+        // shadowRadius: 3.84,
+        // elevation: 5,
+        backgroundColor: 'white',
+    },
+    content: {
+        flex: 1,
+        flexDirection: 'row',
+        overflow: 'hidden',
+    },
+    portraitContent: {
+        flex: 1,
+        overflow: 'hidden',
+    },
+});

--- a/src/shared/components/PageFlipper/portrait/BookPagePortrait.tsx
+++ b/src/shared/components/PageFlipper/portrait/BookPagePortrait.tsx
@@ -1,0 +1,442 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, StyleSheet, View, ViewStyle } from 'react-native';
+import {
+    PanGestureHandler,
+    PanGestureHandlerGestureEvent,
+} from 'react-native-gesture-handler';
+import Animated, {
+    Easing,
+    Extrapolate,
+    interpolate,
+    runOnJS,
+    useAnimatedGestureHandler,
+    useAnimatedStyle,
+    useDerivedValue,
+    useSharedValue,
+    withTiming,
+    WithTimingConfig,
+} from 'react-native-reanimated';
+import type { Page, Size } from '../types';
+import BackShadow from '../BookPage/BackShadow';
+import FrontShadow from '../BookPage/FrontShadow';
+import PageShadow from '../BookPage/PageShadow';
+import { clamp, snapPoint } from '../utils/utils';
+
+export type IBookPageProps = {
+    current: Page;
+    prev: Page;
+    onPageFlip: any;
+    containerSize: Size;
+    setIsAnimating: (val: boolean) => void;
+    isAnimating: boolean;
+    enabled: boolean;
+    isPressable: boolean;
+    getPageStyle: (right: boolean, front: boolean) => any;
+    isAnimatingRef: React.MutableRefObject<boolean>;
+    next: Page;
+    onFlipStart?: (id: number) => void;
+    onPageDragStart?: () => void;
+    onPageDrag?: () => void;
+    onPageDragEnd?: () => void;
+    renderPage?: (data: any) => any;
+};
+
+export type PortraitBookInstance = { turnPage: (index: 1 | -1) => void };
+
+const timingConfig: WithTimingConfig = {
+    duration: 800,
+    easing: Easing.inOut(Easing.cubic),
+};
+
+const BookPagePortrait = React.forwardRef<PortraitBookInstance, IBookPageProps>(
+    (
+        {
+            current,
+            prev,
+            onPageFlip,
+            containerSize,
+            enabled,
+            isPressable,
+            setIsAnimating,
+            getPageStyle,
+            isAnimating,
+            isAnimatingRef,
+            next,
+            onFlipStart,
+            onPageDrag,
+            onPageDragEnd,
+            onPageDragStart,
+            renderPage,
+        },
+        ref
+    ) => {
+        const containerWidth = containerSize.width;
+
+        const pSnapPoints = !prev
+            ? [-containerSize.width, 0]
+            : [-containerSize.width, 0, containerSize.width];
+
+        const x = useSharedValue(0);
+
+        const isMounted = useRef(false);
+        const rotateYAsDeg = useSharedValue(0);
+
+        // might not need this
+        // useEffect(() => {
+        //   if (!enabled) {
+        //     setIsDragging(false);
+        //   }
+        // }, [enabled]);
+
+        const turnPage = useCallback(
+            (id: 1 | -1) => {
+                setIsAnimating(true);
+                if (onFlipStart && typeof onFlipStart === 'function') {
+                    onFlipStart(id);
+                }
+                rotateYAsDeg.value = withTiming(
+                    id < 0 ? -180 : 180,
+                    timingConfig,
+                    () => {
+                        runOnJS(onPageFlip)(id, false);
+                    }
+                );
+            },
+            [onFlipStart, onPageFlip, rotateYAsDeg, setIsAnimating]
+        );
+
+        React.useImperativeHandle(
+            ref,
+            () => ({
+                turnPage,
+            }),
+            [turnPage]
+        );
+
+        useEffect(() => {
+            isMounted.current = true;
+            return () => {
+                isMounted.current = false;
+            };
+        }, []);
+
+        const getDegreesForX = (x: number) => {
+            'worklet';
+
+            const val = interpolate(
+                x,
+                [-containerSize.width, 0, containerSize.width],
+                [180, 0, -180],
+                Extrapolate.CLAMP
+            );
+            return val;
+        };
+
+        const containerStyle = useAnimatedStyle(() => {
+            return {
+                flex: 1,
+            };
+        });
+
+        const onPanGestureHandler = useAnimatedGestureHandler<
+            PanGestureHandlerGestureEvent,
+            { x: number }
+        >({
+            // @ts-ignore
+            onStart: (event, ctx) => {
+                ctx.x = x.value;
+                if (onPageDragStart && typeof onPageDragStart === 'function') {
+                    runOnJS(onPageDragStart)();
+                }
+            },
+            onActive: (event, ctx) => {
+                const newX = ctx.x + event.translationX;
+                const degrees = getDegreesForX(newX);
+                x.value = newX;
+                rotateYAsDeg.value = degrees;
+                if (onPageDrag && typeof onPageDrag === 'function') {
+                    runOnJS(onPageDrag)();
+                }
+            },
+            onEnd: (event) => {
+                if (onPageDragEnd && typeof onPageDragEnd === 'function') {
+                    runOnJS(onPageDragEnd)();
+                }
+
+                const snapTo = snapPoint(x.value, event.velocityX, pSnapPoints);
+                const id = snapTo > 0 ? -1 : snapTo < 0 ? 1 : 0;
+
+                if (!next && id > 0) {
+                    // reset
+                    x.value = withTiming(0);
+                    rotateYAsDeg.value = withTiming(0);
+                    // runOnJS(onDrag)(false);
+                    return;
+                }
+
+                const degrees = getDegreesForX(snapTo);
+                x.value = snapTo;
+                if (rotateYAsDeg.value === degrees) {
+                    // already same value
+                    // debugValue('already there');
+                    runOnJS(onPageFlip)(id, false);
+                } else {
+                    runOnJS(setIsAnimating)(true);
+
+                    const progress =
+                        Math.abs(rotateYAsDeg.value - degrees) / 100;
+                    const duration = clamp(
+                        800 * progress - Math.abs(0.1 * event.velocityX),
+                        350,
+                        1000
+                    );
+                    rotateYAsDeg.value = withTiming(
+                        degrees,
+                        {
+                            ...timingConfig,
+                            duration: duration,
+                        },
+                        () => {
+                            if (snapTo === 0) {
+                                //
+                            }
+                            runOnJS(onPageFlip)(id, false);
+                        }
+                    );
+                }
+            },
+        });
+
+        const gesturesEnabled = enabled && !isAnimating;
+
+        const iPageProps = {
+            containerSize,
+            containerWidth,
+            getPageStyle,
+            rotateYAsDeg,
+            renderPage,
+        };
+
+        return (
+            <Animated.View style={containerStyle}>
+                <PanGestureHandler
+                    onGestureEvent={onPanGestureHandler}
+                    enabled={gesturesEnabled}
+                >
+                    <Animated.View style={containerStyle}>
+                        {isPressable && prev && (
+                            <Pressable
+                                disabled={isAnimating}
+                                onPress={() => {
+                                    if (!isAnimatingRef.current) turnPage(-1);
+                                }}
+                                style={{
+                                    position: 'absolute',
+                                    height: '100%',
+                                    width: '25%',
+                                    zIndex: 10000,
+                                    left: 0,
+                                    // backgroundColor: 'red',
+                                    // opacity: 0.2,
+                                }}
+                            />
+                        )}
+                        {isPressable && next && (
+                            <Pressable
+                                disabled={isAnimating}
+                                onPress={() => {
+                                    if (!isAnimatingRef.current) turnPage(1);
+                                }}
+                                style={{
+                                    position: 'absolute',
+                                    height: '100%',
+                                    width: '30%',
+                                    zIndex: 10000,
+                                    right: 0,
+                                    // backgroundColor: 'blue',
+                                    // opacity: 0.2,
+                                }}
+                            />
+                        )}
+                        {current && next ? (
+                            <IPage
+                                page={current}
+                                right={true}
+                                {...iPageProps}
+                            />
+                        ) : (
+                            <View style={{ height: '100%', width: '100%' }}>
+                                {renderPage && (
+                                    <View style={getPageStyle(true, true)}>
+                                        {renderPage(current.right)}
+                                    </View>
+                                )}
+                            </View>
+                        )}
+                        {prev && (
+                            <IPage page={prev} right={false} {...iPageProps} />
+                        )}
+                    </Animated.View>
+                </PanGestureHandler>
+            </Animated.View>
+        );
+    }
+);
+
+type IPageProps = {
+    right: boolean;
+    page: Page;
+    rotateYAsDeg: Animated.SharedValue<number>;
+    containerWidth: number;
+    containerSize: Size;
+    getPageStyle: any;
+    renderPage?: (data: any) => any;
+};
+
+const IPage: React.FC<IPageProps> = ({
+    right,
+    page,
+    rotateYAsDeg,
+    containerWidth,
+    containerSize,
+    getPageStyle,
+    renderPage,
+}) => {
+    const [loaded, setLoaded] = useState(right);
+
+    useEffect(() => {
+        // hack fix
+        setTimeout(() => {
+            setLoaded(true);
+        }, 50);
+    }, []);
+
+    const rotationVal = useDerivedValue(() => {
+        const val = right
+            ? rotateYAsDeg.value
+            : interpolate(rotateYAsDeg.value, [-180, 0], [0, 180]);
+        return val;
+    });
+
+    const portraitBackStyle = useAnimatedStyle(() => {
+        const x = interpolate(
+            rotationVal.value,
+            [0, 180],
+            [containerWidth, -containerWidth / 2]
+        );
+        const w = interpolate(
+            rotationVal.value,
+            [0, 180],
+            [0, containerWidth / 2]
+        );
+
+        return {
+            width: Math.ceil(w),
+            zIndex: 2,
+            opacity: 1,
+            transform: [{ translateX: x }],
+        };
+    });
+
+    const portraitFrontStyle = useAnimatedStyle(() => {
+        const w = interpolate(
+            rotationVal.value,
+            [0, 160],
+            [containerWidth, -20],
+            Extrapolate.CLAMP
+        );
+
+        const style: ViewStyle = {
+            zIndex: 1,
+            width: Math.floor(w),
+        };
+
+        if (!right) {
+            style['left'] = 0;
+        } else {
+            // style['right'] = 0;
+        }
+
+        return style;
+    });
+
+    const frontPageStyle = getPageStyle(right, true);
+    const backPageStyle = getPageStyle(right, false);
+
+    if (!loaded) {
+        // hack fix
+        return null;
+    }
+
+    const shadowProps = {
+        right: true,
+        degrees: rotationVal,
+        width: containerSize.width,
+        viewHeight: containerSize.height,
+    };
+
+    return (
+        <View
+            style={{
+                ...StyleSheet.absoluteFillObject,
+                zIndex: !right ? 5 : 0,
+            }}
+        >
+            {/* BACK */}
+            <Animated.View
+                style={[
+                    styles.pageContainer,
+                    portraitBackStyle,
+                    { overflow: 'visible' },
+                ]}
+            >
+                <View style={styles.pageContainer}>
+                    {renderPage && (
+                        <Animated.View
+                            style={[
+                                backPageStyle,
+
+                                {
+                                    opacity: 0.2,
+                                    transform: [
+                                        { rotateX: '180deg' },
+                                        { rotateZ: '180deg' },
+                                    ],
+                                },
+                            ]}
+                        >
+                            {renderPage(page.left)}
+                        </Animated.View>
+                    )}
+                </View>
+                <BackShadow {...{ degrees: rotationVal, right: true }} />
+                <FrontShadow {...shadowProps} />
+                <PageShadow {...shadowProps} containerSize={containerSize} />
+            </Animated.View>
+            {/* FRONT */}
+            <Animated.View style={[styles.pageContainer, portraitFrontStyle]}>
+                {renderPage && (
+                    <Animated.View style={[frontPageStyle]}>
+                        {renderPage(page.left)}
+                    </Animated.View>
+                )}
+            </Animated.View>
+        </View>
+    );
+};
+
+export { BookPagePortrait };
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    pageContainer: {
+        height: '100%',
+        width: '100%',
+        position: 'absolute',
+        backfaceVisibility: 'hidden',
+        overflow: 'hidden',
+        backgroundColor: 'white',
+    },
+});

--- a/src/shared/components/PageFlipper/types.ts
+++ b/src/shared/components/PageFlipper/types.ts
@@ -1,0 +1,9 @@
+export type Size = {
+    height: number;
+    width: number;
+};
+
+export type Page = {
+    left: string;
+    right: string;
+};

--- a/src/shared/components/PageFlipper/utils/utils.ts
+++ b/src/shared/components/PageFlipper/utils/utils.ts
@@ -1,0 +1,97 @@
+import { runOnJS } from 'react-native-reanimated';
+import type { Page } from '../types';
+import type { TransformsStyle } from 'react-native';
+
+export const createPages = ({
+    portrait,
+    singleImageMode,
+    data,
+}: {
+    portrait: boolean;
+    singleImageMode: boolean;
+    data: string[];
+}) => {
+    const allPages: Page[] = [];
+
+    if (portrait) {
+        if (!singleImageMode) {
+            data.forEach((page) => {
+                allPages.push({
+                    left: page,
+                    right: page,
+                });
+                allPages.push({
+                    left: page,
+                    right: page,
+                });
+            });
+        } else {
+            for (let i = 0; i < data.length; i++) {
+                allPages[i] = {
+                    left: data[i],
+                    right: data[i],
+                };
+            }
+        }
+    } else {
+        for (let i = 0; i < data.length; i++) {
+            if (singleImageMode) {
+                allPages.push({
+                    left: data[i],
+                    right: data[i + 1],
+                });
+                i++;
+            } else {
+                allPages.push({
+                    left: data[i],
+                    right: data[i],
+                });
+            }
+        }
+    }
+    return allPages;
+};
+
+type RNTransform = Exclude<TransformsStyle['transform'], undefined>;
+
+export const transformOrigin = (
+    { x, y }: { x: number; y: number },
+    transformations: RNTransform
+): RNTransform => {
+    'worklet';
+    // @ts-ignore - Reanimated transform 타입 복잡성
+    return [
+        { translateX: x },
+        { translateY: y },
+        ...transformations,
+        { translateX: -x },
+        { translateY: -y },
+    ];
+};
+
+const debug = (msg: string, val: any) => {
+    console.log(msg, val);
+};
+
+export const debugValue = (msg: string, val: any) => {
+    'worklet';
+    runOnJS(debug)(msg, val);
+};
+
+export const snapPoint = (
+    value: number,
+    velocity: number,
+    points: ReadonlyArray<number>
+): number => {
+    'worklet';
+
+    const point = value + 0.25 * velocity;
+    const deltas = points.map((p) => Math.abs(point - p));
+    const minDelta = Math.min.apply(null, deltas);
+    return points.filter((p) => Math.abs(point - p) === minDelta)[0];
+};
+
+export function clamp(number: number, min: number, max: number) {
+    'worklet';
+    return Math.max(min, Math.min(number, max));
+}

--- a/src/shared/components/index.ts
+++ b/src/shared/components/index.ts
@@ -1,0 +1,1 @@
+export { AppInitializer } from './AppInitializer';

--- a/src/widgets/StoryReaderPage/model/useStoryReaderPage.ts
+++ b/src/widgets/StoryReaderPage/model/useStoryReaderPage.ts
@@ -22,25 +22,25 @@ const mockStoryPages: StoryPage[] = [
     id: '2',
     title: '구름 위의 성',
     content: '하늘 높이 떠 있는 구름 위에 아름다운 성이 있었습니다. 그곳에는 날개 달린 사람들이 살고 있었고, 항상 행복한 노래가 울려 퍼졌습니다. 아이는 구름을 타고 성에 도착했고, 하늘의 비밀을 알게 되었습니다.',
-    imageUrl: 'https://images.unsplash.com/photo-1518709268805-4e9042af2176?w=800&h=600&fit=crop&crop=center'
+    imageUrl: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=800&h=600&fit=crop&crop=center'
   },
   {
     id: '3',
     title: '바다 속 보물',
     content: '깊은 바다 속에는 신비로운 보물들이 숨어있었습니다. 물고기들은 친구가 되어 아이를 안내했고, 함께 보물을 찾아 나섰습니다. 바다의 깊은 곳에는 고대 문명의 흔적도 남아있었습니다.',
-    imageUrl: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=800&h=600&fit=crop&crop=center'
+    imageUrl: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&h=600&fit=crop&crop=center'
   },
   {
     id: '4',
     title: '달나라 토끼',
     content: '달에는 흰 토끼가 살고 있었습니다. 토끼는 떡을 만들며 아이들에게 꿈을 선물했고, 밤하늘을 밝게 비추었습니다. 달나라에는 별들이 꽃처럼 피어있었고, 아이는 그곳에서 평화를 찾았습니다.',
-    imageUrl: 'https://images.unsplash.com/photo-1532693322450-2cb5c2e4a9c2?w=800&h=600&fit=crop&crop=center'
+    imageUrl: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&h=600&fit=crop&crop=center'
   },
   {
     id: '5',
     title: '시간의 문',
     content: '마지막 페이지에서 아이는 시간의 문을 발견했습니다. 그 문을 열면 새로운 모험이 시작되고, 또 다른 동화가 펼쳐질 것입니다. 아이는 이제 자신만의 이야기를 만들어갈 준비가 되었습니다.',
-    imageUrl: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&h=600&fit=crop&crop=center'
+    imageUrl: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=800&h=600&fit=crop&crop=center'
   }
 ];
 
@@ -85,37 +85,19 @@ export const useStoryReaderPage = (storyId: string) => {
     };
   }, []);
 
-  const currentPage = mockStoryPages[currentPageIndex];
-  const totalPages = mockStoryPages.length;
-
   const handleBack = useCallback(() => {
     router.back();
   }, [router]);
 
-  const handlePrevious = useCallback(() => {
-    if (currentPageIndex > 0) {
-      setCurrentPageIndex(prev => prev - 1);
-    }
-  }, [currentPageIndex]);
-
-  const handleNext = useCallback(() => {
-    if (currentPageIndex < totalPages - 1) {
-      setCurrentPageIndex(prev => prev + 1);
-    }
-  }, [currentPageIndex, totalPages]);
-
-  const canGoPrevious = currentPageIndex > 0;
-  const canGoNext = currentPageIndex < totalPages - 1;
+  const handlePageChange = useCallback((pageIndex: number) => {
+    setCurrentPageIndex(pageIndex);
+  }, []);
 
   return {
-    currentPage,
-    currentPageIndex: currentPageIndex + 1, // 1부터 시작하는 페이지 번호
-    totalPages,
+    pages: mockStoryPages,
+    initialPage: currentPageIndex,
     isLandscape,
     handleBack,
-    handlePrevious,
-    handleNext,
-    canGoPrevious,
-    canGoNext,
+    handlePageChange,
   };
 };

--- a/src/widgets/StoryReaderPage/ui/StoryReaderPage.tsx
+++ b/src/widgets/StoryReaderPage/ui/StoryReaderPage.tsx
@@ -1,16 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, Dimensions, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { View, Text, Dimensions, TouchableOpacity, ActivityIndicator, Image } from 'react-native';
 import styled from '@emotion/native';
-import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, { 
-  useSharedValue, 
-  useAnimatedGestureHandler, 
-  useAnimatedStyle, 
-  withSpring,
-  runOnJS,
-  interpolate,
-  Extrapolate
-} from 'react-native-reanimated';
+// @ts-ignore - 복사한 PageFlipper 컴포넌트 사용
+import PageFlipper from '../../../shared/components/PageFlipper/index';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
 
@@ -61,85 +53,7 @@ const PageIndicatorText = styled.Text`
   font-weight: 500;
 `;
 
-const ContentContainer = styled.View`
-  flex: 1;
-  flex-direction: row;
-`;
 
-const ImageContainer = styled.View`
-  flex: 1;
-  justify-content: center;
-  align-items: center;
-  background-color: #1a1a1a;
-`;
-
-const StoryImage = styled.Image`
-  width: 100%;
-  height: 100%;
-  resize-mode: contain;
-`;
-
-const ImageLoadingContainer = styled.View`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  justify-content: center;
-  align-items: center;
-  background-color: #1a1a1a;
-`;
-
-const StoryContainer = styled.View`
-  flex: 1;
-  padding: 32px;
-  justify-content: center;
-  background-color: rgba(0, 0, 0, 0.8);
-`;
-
-const StoryTitle = styled.Text`
-  color: #ffffff;
-  font-size: 28px;
-  font-weight: 700;
-  margin-bottom: 24px;
-  text-align: center;
-  line-height: 36px;
-`;
-
-const StoryContent = styled.Text`
-  color: #ffffff;
-  font-size: 18px;
-  line-height: 28px;
-  text-align: center;
-  opacity: 0.9;
-`;
-
-const NavigationContainer = styled.View`
-  position: absolute;
-  bottom: 32px;
-  left: 0;
-  right: 0;
-  flex-direction: row;
-  justify-content: center;
-  gap: 16px;
-`;
-
-const NavButton = styled.TouchableOpacity<{ disabled?: boolean }>`
-  width: 56px;
-  height: 56px;
-  border-radius: 28px;
-  background-color: ${props => props.disabled ? 'rgba(255, 255, 255, 0.1)' : 'rgba(255, 255, 255, 0.2)'};
-  align-items: center;
-  justify-content: center;
-  opacity: ${props => props.disabled ? 0.5 : 1};
-  backdrop-filter: blur(10px);
-`;
-
-const NavButtonText = styled.Text`
-  color: #ffffff;
-  font-size: 20px;
-  font-weight: 600;
-`;
 
 const SwipeHint = styled.View`
   position: absolute;
@@ -159,39 +73,32 @@ const SwipeHintText = styled.Text`
   border-radius: 20px;
 `;
 
-interface StoryReaderPageProps {
-  currentPage: number;
-  totalPages: number;
-  storyTitle: string;
-  storyContent: string;
+interface StoryPageData {
+  id: string;
+  title: string;
+  content: string;
   imageUrl: string;
+}
+
+interface StoryReaderPageProps {
+  pages: StoryPageData[];
+  initialPage?: number;
   onBack: () => void;
-  onPrevious: () => void;
-  onNext: () => void;
-  canGoPrevious: boolean;
-  canGoNext: boolean;
+  onPageChange?: (pageIndex: number) => void;
 }
 
 export const StoryReaderPage: React.FC<StoryReaderPageProps> = ({
-  currentPage,
-  totalPages,
-  storyTitle,
-  storyContent,
-  imageUrl,
+  pages,
+  initialPage = 0,
   onBack,
-  onPrevious,
-  onNext,
-  canGoPrevious,
-  canGoNext,
+  onPageChange,
 }) => {
-  const [imageLoading, setImageLoading] = useState(true);
+  const [currentPageIndex, setCurrentPageIndex] = useState(initialPage);
   const [showSwipeHint, setShowSwipeHint] = useState(true);
-  const translateX = useSharedValue(0);
-  const opacity = useSharedValue(1);
 
   // 첫 페이지에서만 스와이프 힌트를 2초간 보여주기
   useEffect(() => {
-    if (currentPage === 1) {
+    if (currentPageIndex === 0) {
       setShowSwipeHint(true);
       const timer = setTimeout(() => {
         setShowSwipeHint(false);
@@ -201,46 +108,67 @@ export const StoryReaderPage: React.FC<StoryReaderPageProps> = ({
     } else {
       setShowSwipeHint(false);
     }
-  }, [currentPage]);
+  }, [currentPageIndex]);
 
-  const gestureHandler = useAnimatedGestureHandler({
-    onStart: (_, context: any) => {
-      context.startX = translateX.value;
-    },
-    onActive: (event, context) => {
-      translateX.value = context.startX + event.translationX;
-      
-      // 스와이프 중일 때 투명도 조절
-      const progress = Math.abs(event.translationX) / (screenWidth * 0.3);
-      opacity.value = interpolate(progress, [0, 1], [1, 0.7], Extrapolate.CLAMP);
-    },
-    onEnd: (event) => {
-      const threshold = screenWidth * 0.3;
-      
-      if (event.translationX > threshold && canGoPrevious) {
-        runOnJS(onPrevious)();
-      } else if (event.translationX < -threshold && canGoNext) {
-        runOnJS(onNext)();
-      }
-      
-      translateX.value = withSpring(0);
-      opacity.value = withSpring(1);
-    },
-  });
-
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      transform: [{ translateX: translateX.value }],
-      opacity: opacity.value,
-    };
-  });
-
-  const handleImageLoad = () => {
-    setImageLoading(false);
+  const handlePageChange = (pageIndex: number) => {
+    setCurrentPageIndex(pageIndex);
+    onPageChange?.(pageIndex);
   };
 
-  const handleImageError = () => {
-    setImageLoading(false);
+  const renderStoryPage = (pageId: string) => {
+    const page = pages.find(p => p.id === pageId);
+    if (!page) return null;
+
+    return (
+      <View style={{
+        flex: 1,
+        flexDirection: 'row',
+        backgroundColor: '#000000',
+      }}>
+        {/* 왼쪽 절반 - 이미지 */}
+        <View style={{
+          flex: 1,
+          backgroundColor: '#1a1a1a',
+        }}>
+          <Image 
+            source={{ uri: page.imageUrl }} 
+            style={{
+              width: '100%',
+              height: '100%',
+              resizeMode: 'cover',
+            }}
+          />
+        </View>
+
+        {/* 오른쪽 절반 - 텍스트 */}
+        <View style={{
+          flex: 1,
+          backgroundColor: '#000000',
+          padding: 40,
+          justifyContent: 'center',
+        }}>
+          <Text style={{
+            color: '#ffffff',
+            fontSize: 24,
+            fontWeight: '700',
+            marginBottom: 24,
+            textAlign: 'center',
+            lineHeight: 32,
+          }}>
+            {page.title}
+          </Text>
+          <Text style={{
+            color: '#ffffff',
+            fontSize: 16,
+            lineHeight: 24,
+            textAlign: 'justify',
+            opacity: 0.95,
+          }}>
+            {page.content}
+          </Text>
+        </View>
+      </View>
+    );
   };
 
   return (
@@ -250,43 +178,24 @@ export const StoryReaderPage: React.FC<StoryReaderPageProps> = ({
           <BackButtonText>←</BackButtonText>
         </BackButton>
         <PageIndicator>
-          <PageIndicatorText>{currentPage} / {totalPages}</PageIndicatorText>
+          <PageIndicatorText>{currentPageIndex + 1} / {pages.length}</PageIndicatorText>
         </PageIndicator>
       </Header>
 
-      <PanGestureHandler onGestureEvent={gestureHandler}>
-        <Animated.View style={[{ flex: 1 }, animatedStyle]}>
-          <ContentContainer>
-            <ImageContainer>
-              <StoryImage 
-                source={{ uri: imageUrl }} 
-                onLoad={handleImageLoad}
-                onError={handleImageError}
-              />
-              {imageLoading && (
-                <ImageLoadingContainer>
-                  <ActivityIndicator size="large" color="#ffffff" />
-                </ImageLoadingContainer>
-              )}
-            </ImageContainer>
-            <StoryContainer>
-              <StoryTitle>{storyTitle}</StoryTitle>
-              <StoryContent>{storyContent}</StoryContent>
-            </StoryContainer>
-          </ContentContainer>
-        </Animated.View>
-      </PanGestureHandler>
+      <PageFlipper
+        data={pages.map(page => page.id)}
+        pageSize={{ width: screenWidth, height: screenHeight  }}
+        contentContainerStyle={{ 
+          flex: 1,
+          backgroundColor: '#000000',
+        }}
+        singleImageMode={false}
+        portrait={false}
+        onFlippedEnd={handlePageChange}
+        renderPage={renderStoryPage}
+      />
 
-      <NavigationContainer>
-        <NavButton onPress={onPrevious} disabled={!canGoPrevious}>
-          <NavButtonText>‹</NavButtonText>
-        </NavButton>
-        <NavButton onPress={onNext} disabled={!canGoNext}>
-          <NavButtonText>›</NavButtonText>
-        </NavButton>
-      </NavigationContainer>
-
-      {totalPages > 1 && showSwipeHint && (
+      {pages.length > 1 && showSwipeHint && (
         <SwipeHint>
           <SwipeHintText>좌우로 스와이프하여 페이지를 넘기세요</SwipeHintText>
         </SwipeHint>


### PR DESCRIPTION
## 연관 이슈
- #27 

## 작업 요약
- StoryReaderPage에 react-native-page-flipper 라이브러리를 통합하여 실제 책 페이지를 넘기는 듯한 애니메이션 효과를 구현

## 작업 상세 설명
- 라이브러리 Expo Go 호환성 작업
  - react-native-page-flipper 라이브러리를 GitHub에서 설치 (github:chris24elias/react-native-page-flipper)
  - Expo Go 환경에서 작동하도록 react-native-linear-gradient → expo-linear-gradient 패치 적용
  - pnpm patch 시스템을 활용하여 라이브러리 호환성 보장
  - 라이브러리 소스 코드를 src/shared/components/PageFlipper/에 복사하여 직접 제어 가능하도록 구성

- StoryReaderPage 리팩토링
  - 기존: PanGestureHandler + useAnimatedGestureHandler를 통한 수동 제스처 처리 
  - 변경: PageFlipper 컴포넌트를 활용한 자동 페이지 넘김 애니메이션
  - 레이아웃: 각 페이지를 "왼쪽 이미지 + 오른쪽 텍스트" 구조로 전체 화면 활용
  - 페이지 구조: 5개 페이지 → 정확히 5번의 페이지 넘김 동작

## 기타

